### PR TITLE
Send full LaTeX error logs

### DIFF
--- a/what_FIXED (1).js
+++ b/what_FIXED (1).js
@@ -9741,7 +9741,7 @@ async function compileLatexDocument({
                     // Find the first non-null capturing group that doesn't start with "! LaTeX Error:"
                     relevantErrorLog = errorMatch.slice(1).find(m => m && !m.startsWith("! LaTeX Error:")) || relevantErrorLog;
                 }
-                relevantErrorLog = relevantErrorLog.split('\n').slice(0, 10).join('\n'); // Keep it somewhat concise
+                // Use the full error message without truncation for clearer debugging
             }
             if (stdout && (!stderr || stderr.length < 50)) { // Show some stdout if stderr is minimal
                 console.log("LaTeX stdout (on error):", stdout.substring(0, 500));
@@ -9784,7 +9784,10 @@ async function compileLatexDocument({
                 await triggeringMsg.reply(`פיתי\n\nמצטערת, יצירת המסמך נכשלה גם לאחר ניסיון חוזר. שגיאת LaTeX עיקרית:\n\`\`\`${errorMessageForUser.slice(0, 250)}...\`\`\``);
                 const fullErrorLogForOwner = `LaTeX Compilation Failed for ${texPath} after ${maxRetries + 1} attempts.\nUser Error: ${errorMessageForUser}\nOriginal Error: ${error.message}\nStdout:\n${stdout}\nStderr:\n${stderr}`;
                 if (client && client.sendMessage && myId) { // בדיקה נוספת לפני שליחה לבעלים
-                    client.sendMessage(myId, fullErrorLogForOwner.substring(0, 4000));
+                    const chunkSize = 4000; // WhatsApp messages have length limits
+                    for (let i = 0; i < fullErrorLogForOwner.length; i += chunkSize) {
+                        await client.sendMessage(myId, fullErrorLogForOwner.substring(i, i + chunkSize));
+                    }
                 }
                 delete triggeringMsg.latexRetryCount;
             }

--- a/whatsapp_modules/fileSystemHelpers.js
+++ b/whatsapp_modules/fileSystemHelpers.js
@@ -143,7 +143,7 @@ function saveLatexError(chatPaths, newErrorLog) {
     let errors = loadLatexErrors(chatPaths);
     errors.unshift({
         timestamp: new Date().toISOString(),
-        errorLog: newErrorLog.substring(0, 1500) // Keep it reasonably sized
+        errorLog: newErrorLog // Store full error log without truncation
     });
     if (errors.length > MAX_LATEX_ERRORS_TO_KEEP) {
         errors = errors.slice(0, MAX_LATEX_ERRORS_TO_KEEP);


### PR DESCRIPTION
## Summary
- keep complete LaTeX error log in `saveLatexError`
- avoid truncating LaTeX stderr when compiling documents
- send long logs to owner in chunks

## Testing
- `node --check "what_FIXED (1).js"`
- `node --check whatsapp_modules/fileSystemHelpers.js`
- `npm install` *(fails: Failed to download Chromium due to blocked domain)*

------
https://chatgpt.com/codex/tasks/task_e_685c5adac5cc8323abedc7f561223c0f