### PR TITLE
Enable commands in group chats

### DIFF
--- a/what_FIXED (1).js
+++ b/what_FIXED (1).js
@@ -10929,14 +10929,15 @@ client.on('message_create', async (msg) => {
         incoming.includes("פייטי");
 
     const botTriggeredByWordOrReplyToBot = isTriggerWord || isReplyToBot;
+    const isCommandMsg = incoming.startsWith('/');
 
     let shouldProcess = false;
 
     if (isGroup) {
-        // בקבוצות: רק אם יש מילת טריגר או תגובה לבוט, וזו *לא* תגובה להודעת הבעלים
-        if (botTriggeredByWordOrReplyToBot && !isReplyToOwner) {
+        // בקבוצות: יש לעבד אם יש מילת טריגר/תגובה לבוט או אם זו פקודה, וזו *לא* תגובה להודעת הבעלים
+        if ((botTriggeredByWordOrReplyToBot || isCommandMsg) && !isReplyToOwner) {
             shouldProcess = true;
-            console.log(`[message_create DECISION] Group message ${msg.id._serialized} IS triggered (word/replyToBot) AND NOT reply to owner. Processing.`);
+            console.log(`[message_create DECISION] Group message ${msg.id._serialized} IS triggered (word/replyToBot/command) AND NOT reply to owner. Processing.`);
         } else {
             // console.log(`[message_create DECISION] Group message ${msg.id._serialized} ignored (not triggered by word/replyToBot or IS reply to owner).`);
         }


### PR DESCRIPTION
## Summary
- handle command messages in groups by treating them as triggers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c73ab089c8323906f88b66c4db3f7