### PR TITLE
Fix group command auth check

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1334,8 +1334,8 @@ async function handleGroupManagementAction(actionData, targetMsg) {
     /* --- OWNER-AUTH CHECK ---------------------------------------- */
     // בקבוצות sender נמצא בשדה author; בהודעות פרטיות – from
     const senderFullId = targetMsg.author || (targetMsg.fromMe ? myId : targetMsg.from);
-    const senderBase = getBaseId(senderFullId);
-    const ownerBase = getBaseId(myId);
+    const senderBase = getBaseIdForOwnerCheck(senderFullId);
+    const ownerBase = getBaseIdForOwnerCheck(myId);
 
     if (senderBase !== ownerBase) {
         await targetMsg.reply("⚠️ אין לך הרשאה לביצוע פקודות ניהול בקבוצה זו.");


### PR DESCRIPTION
## Summary
- fix owner permission check for group management commands

## Testing
- `npm test` *(fails: Missing script)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685c78f1032c8323b60320326d034f5a