### PR TITLE
Fix mention reply and error handling

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -8292,12 +8292,20 @@ ${internalLinks.map((l, i) => `${i + 1}. ${l}`).join('\n')}
 
                 if (jsonResponse.respond !== false) {
                     const sentMsg = await msg.reply(`פיתי\n\n@${name}\n${jsonResponse.message}`, undefined, {
-                        mentions: [mentionContact]
+                        // whatsapp-web.js no longer accepts Contact objects in the
+                        // mentions array. Pass the contact's ID instead to avoid
+                        // deprecation warnings and potential failures.
+                        mentions: [mentionContact.id._serialized]
+                    }).catch(err => {
+                        console.error('Failed to send mention reply:', err);
+                        return null;
                     });
 
-                    const normId = normalizeMsgId(sentMsg.id._serialized);
-                    botMessageIds.add(normId);
-                    repliableMessageIds.add(normId);
+                    if (sentMsg?.id) {
+                        const normId = normalizeMsgId(sentMsg.id._serialized);
+                        botMessageIds.add(normId);
+                        repliableMessageIds.add(normId);
+                    }
 
                     return;
                 } else {
@@ -8312,14 +8320,20 @@ ${internalLinks.map((l, i) => `${i + 1}. ${l}`).join('\n')}
         console.error("❌ שגיאה בטיפול בלוגיקת replyTo:", error);
 
         // שליחת הודעת שגיאה למשתמש
-        const sentMsg = await msg.reply("פיתי\n\nאירעה שגיאה בזמן ניסיון התגובה.");
+        const sentMsg = await msg.reply("פיתי\n\nאירעה שגיאה בזמן ניסיון התגובה.")
+            .catch(err => {
+                console.error('Failed to send error notice:', err);
+                return null;
+            });
 
-        // נרמול ה-ID (מסיר ‎true_/false_‎ אם קיימים)
-        const normId = normalizeMsgId(sentMsg.id._serialized);
+        if (sentMsg?.id) {
+            // נרמול ה-ID (מסיר ‎true_/false_‎ אם קיימים)
+            const normId = normalizeMsgId(sentMsg.id._serialized);
 
-        // שמירה במבני-הנתונים הנכונים
-        botMessageIds.add(normId);
-        repliableMessageIds.add(normId);
+            // שמירה במבני-הנתונים הנכונים
+            botMessageIds.add(normId);
+            repliableMessageIds.add(normId);
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- avoid deprecated contact array mentions by using contact id
- guard against failed `msg.reply` calls so error handling doesn't throw

## Testing
- `node -c bot.js`

------
https://chatgpt.com/codex/tasks/task_e_685d295add088323a010a584d9ec8d2c