### PR TITLE
Fix add participant when quoting message

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1413,8 +1413,9 @@ async function handleGroupManagementAction(actionData, targetMsg) {
                 const originalQuotedMsgBySender = await targetMsg.getQuotedMessage(); // ההודעה שהמשתמש המבקש ציטט
                 const participantId = originalQuotedMsgBySender.author || originalQuotedMsgBySender.from;
                 if (participantId) {
-                    finalParticipantIds.push(participantId);
-                    console.log(`[GroupMgmt] Identified participant ${participantId} from user's quoted message.`);
+                    const normalizedId = getBaseIdForOwnerCheck(participantId);
+                    finalParticipantIds.push(normalizedId);
+                    console.log(`[GroupMgmt] Identified participant ${normalizedId} from user's quoted message.`);
                 } else {
                     console.warn("[GroupMgmt] 'quotedParticipantTarget' is true, but couldn't extract participant ID from user's quoted message.");
                 }


### PR DESCRIPTION
## Summary
- sanitize participant IDs extracted from quoted messages to ensure they end with `@c.us`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d3271671883238447a77242239efb