### PR TITLE
Fix Puppeteer launch error

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -24,7 +24,8 @@ const messageMap = new Map();
 const mime = require('mime-types');
 const COGVIDEO_GRADIO_SPACE = "THUDM/CogVideoX-5B-Space"; // CogVideoX Space URL
 // בתחילת הקובץ, ליד שאר הקבועים של Cloudflare
-const puppeteer = require('puppeteer-core');
+// Use bundled Chromium to avoid specifying executablePath
+const puppeteer = require('puppeteer');
 
 
 


### PR DESCRIPTION
## Summary
- use the bundled `puppeteer` package instead of `puppeteer-core`

## Testing
- `node --check bot.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e7af2fb588323a2f6d51c25ee6f85