### PR TITLE
Fix puppeteer launch options

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -7400,7 +7400,10 @@ allprojects {
     const { URL } = require("url");
 
     async function extractInternalLinks(url) {
-        const browser = await puppeteer.launch({ headless: "new" });
+        const browser = await puppeteer.launch({
+            headless: "new",
+            args: ["--no-sandbox", "--disable-setuid-sandbox"]
+        });
         const page = await browser.newPage();
 
         try {

--- a/searchAndExtract.js
+++ b/searchAndExtract.js
@@ -1,7 +1,10 @@
 ﻿const puppeteer = require("puppeteer");
 
 async function searchDuckDuckGoTop10(query) {
-    const browser = await puppeteer.launch({ headless: "new" });
+    const browser = await puppeteer.launch({
+        headless: "new",
+        args: ["--no-sandbox", "--disable-setuid-sandbox"]
+    });
     const page = await browser.newPage();
 
     await page.goto("https://html.duckduckgo.com/html/");


### PR DESCRIPTION
## Summary
- add `--no-sandbox` args to the puppeteer launches in `searchAndExtract.js`
- apply the same fix for the internal link extraction in `bot.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e7c4c4dac8323901ba02a277d25ae