### PR TITLE
Add profile picture handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "instagram-private-api": "^1.46.1",
     "pikud-haoref-api": "^4.0.0",
     "puppeteer": "^24.10.2",
-    "whatsapp-web.js": "^1.30.1-alpha.3"
+    "whatsapp-web.js": "^1.30.1-alpha.3",
+    "node-fetch": "^2.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `node-fetch` dependency
- implement helpers for downloading, describing and storing user profile pics
- implement handler to send profile photo on `send_profile_pic` action
- store monthly profile picture descriptions when users trigger the bot

## Testing
- `npm install` *(fails: blocked download)*

------
https://chatgpt.com/codex/tasks/task_e_686048ae876c832388faa3aeebf46dad