### PR TITLE
Fix duplicate SVG image message

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -4184,7 +4184,11 @@ async function handleSvgImageAction(replyData, targetMsg, chatPaths) {
         const caption = replyData.message || `פיתי\n\nהנה התמונה שיצרתי מ-SVG:`;
 
         await client.sendMessage(targetChatId, imageMedia, { caption, quotedMessageId: replyTo });
-        await client.sendMessage(targetChatId, svgMedia, { quotedMessageId: replyTo });
+        // Send the raw SVG file as a document so it does not appear as a duplicate image
+        await client.sendMessage(targetChatId, svgMedia, {
+            quotedMessageId: replyTo,
+            sendMediaAsDocument: true
+        });
 
         const indexPath = chatPaths.generatedFilesIndex;
         let indexData = [];


### PR DESCRIPTION
## Summary
- send raw SVG file as a document in `handleSvgImageAction`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866d1c166d48323a5ecd35b6e5196dd