### PR TITLE
Implement Telegram bot features

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "dependencies": {
     "instagram-private-api": "^1.46.1",
+    "node-fetch": "^2.7.0",
+    "node-telegram-bot-api": "^0.66.0",
     "pikud-haoref-api": "^4.0.0",
     "puppeteer": "^24.10.2",
-    "whatsapp-web.js": "^1.30.1-alpha.3",
-    "node-fetch": "^2.7.0"
+    "whatsapp-web.js": "^1.30.1-alpha.3"
   }
 }


### PR DESCRIPTION
## Summary
- add Telegram bot polling and conversation handlers
- manage groups and private chat lists via Telegram
- send/secret messages and fetch chat history from Telegram
- allow toggling of stopped chats from Telegram
- add node-telegram-bot-api dependency

## Testing
- `node -c bot.js`

------
https://chatgpt.com/codex/tasks/task_e_6867c09176548323977fdfc46145bd9a