### PR TITLE
Extend Telegram bot management

### DIFF
--- a/api_keys.json
+++ b/api_keys.json
@@ -1,0 +1,8 @@
+{
+  "gemini": ["AIzaSyDfqo_60y39EG_ZW5Fn3EeB6BoZMru5V_k"],
+  "cloudflare": {
+    "account_id": "38a8437a72c997b85a542a6b64a699e2",
+    "api_token": "jCnlim7diZ_oSCKIkSUxRJGRS972sHEHfgGTmDWK"
+  },
+  "gmail": {}
+}


### PR DESCRIPTION
## Summary
- load external API credentials from new `api_keys.json`
- expose helper functions to send Telegram command menus
- add Telegram commands to restart the bot, view system status and manage API keys
- support exporting/importing memories and searching files via Telegram
- show an interactive command list when a user sends a message without state

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868365e1fe08323868171ecac281e87