### PR TITLE
Fix profile pic retrieval by normalizing user ID

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -424,7 +424,8 @@ async function describeImage(base64Data, mimeType) {
 }
 
 async function downloadProfilePic(client, userId, outputPath) {
-    const url = await client.getProfilePicUrl(userId);
+    const normalizedId = getBaseId(userId);
+    const url = await client.getProfilePicUrl(normalizedId);
     if (!url) throw new Error('No profile picture available.');
     const res = await fetch(url);
     const buffer = await res.buffer();


### PR DESCRIPTION
## Summary
- normalize WhatsApp IDs before retrieving profile pictures

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a83af2dd883239f0fa6a0847ab9e0