### PR TITLE
Fix restart button to restart bot

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1064,12 +1064,26 @@ function restartBotViaTG(chatId) {
     const pythonExecutable = 'python';
     const restartScriptPath = path.join(__dirname, 'restart_bot.py');
     const nodeScript = process.argv[1];
-    if (fs.existsSync(restartScriptPath)) {
-        spawn(pythonExecutable, [restartScriptPath, nodeScript], { detached: true, stdio: 'ignore' }).unref();
-        tgBot.sendMessage(chatId, 'מפעיל מחדש את הבוט...');
-    } else {
+
+    if (!fs.existsSync(restartScriptPath)) {
         tgBot.sendMessage(chatId, 'לא נמצא סקריפט הפעלה.');
+        return;
     }
+
+    if (!nodeScript) {
+        tgBot.sendMessage(chatId, 'שגיאה: לא ניתן לקבוע את נתיב סקריפט הבוט.');
+        return;
+    }
+
+    spawn(pythonExecutable, [restartScriptPath, nodeScript], {
+        detached: true,
+        stdio: 'ignore'
+    }).unref();
+    tgBot.sendMessage(chatId, 'מפעיל מחדש את הבוט...');
+
+    setTimeout(() => {
+        process.exit(1);
+    }, 2000);
 }
 
 tgBot.onText(/\/groups/, async (msg) => {
@@ -1097,15 +1111,7 @@ tgBot.onText(/\/revert/, async (msg) => {
 });
 
 tgBot.onText(/\/restartbot/, async (msg) => {
-    const pythonExecutable = 'python';
-    const restartScriptPath = path.join(__dirname, 'restart_bot.py');
-    const nodeScript = process.argv[1];
-    if (fs.existsSync(restartScriptPath)) {
-        spawn(pythonExecutable, [restartScriptPath, nodeScript], { detached: true, stdio: 'ignore' }).unref();
-        tgBot.sendMessage(msg.chat.id, 'מפעיל מחדש את הבוט...');
-    } else {
-        tgBot.sendMessage(msg.chat.id, 'לא נמצא סקריפט הפעלה.');
-    }
+    restartBotViaTG(msg.chat.id);
 });
 
 tgBot.onText(/\/status/, async (msg) => {


### PR DESCRIPTION
## Summary
- exit the Node.js process after spawning the Python restart script so the bot actually restarts
- reuse the same restart logic for `/restartbot`

## Testing
- `python -m py_compile restart_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_686bb022e9c8832392ff9fbbf944eef3