### PR TITLE
Fix LaTeX output directory

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -11509,13 +11509,16 @@ async function compileLatexDocument({
     // שם קובץ ה-tex בלבד, כי אנחנו נריץ את הפקודה מתוך התיקייה שלו
     const texBaseFilename = path.basename(texPath); // <--- הגדר את המשתנה כאן
     const pdfFilename = `${path.parse(texBaseFilename).name}.pdf`;
-    const pdfPath = path.join(chatPaths.chatDir, pdfFilename);
+    // Ensure PDF path is derived from the same directory as the .tex file
+    const pdfPath = path.join(path.dirname(texPath), pdfFilename);
     const finalOutputDocumentName = `${documentName}.pdf`;
 
     const currentRetry = (triggeringMsg.latexRetryCount || 0);
     const maxRetries = 1;
 
-    const outputDirForLatex = chatPaths.chatDir;
+    // Run LaTeX compilation inside the directory containing the .tex file so
+    // relative paths within the document work correctly
+    const outputDirForLatex = path.dirname(texPath);
     // הפקודה תרוץ עם CWD שמכוון ל-outputDirForLatex, לכן הנתיב לקובץ ה-tex יכול להיות יחסי
     const command = `${xelatexCmd} -interaction=nonstopmode "${texBaseFilename}" && ${xelatexCmd} -interaction=nonstopmode "${texBaseFilename}"`;
 


### PR DESCRIPTION
## Summary
- ensure LaTeX compilation runs inside the same folder as the `.tex` file
- derive the generated PDF path from that directory

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c350de7f883239dc2ba7ac545488f